### PR TITLE
fix: 修復未啟用模組setting閃退

### DIFF
--- a/app/src/main/java/tianci/dev/xptranslatetext/SettingsActivity.java
+++ b/app/src/main/java/tianci/dev/xptranslatetext/SettingsActivity.java
@@ -1,26 +1,57 @@
 package tianci.dev.xptranslatetext;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
 public class SettingsActivity extends AppCompatActivity {
+
+    /**
+     * Normally [MODE_WORLD_READABLE] causes a crash.
+     * But if "xposedsharedprefs" flag is present in AndroidManifest,
+     * then the file is accordingly taken care by lsposed framework.
+     *
+     * If an exception is thrown, means module is not enabled,
+     * hence Android throws a security exception.
+     */
+
     private static final String TAG = "SettingsActivity";
 
+    @SuppressLint("WorldReadableFiles")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 
-        if (savedInstanceState == null) {
-            getSupportFragmentManager()
-                    .beginTransaction()
-                    .replace(R.id.settings_container, new MainPreferenceFragment())
-                    .commit();
+        SharedPreferences pref;
+        try {
+            pref = getSharedPreferences("prefs", MODE_WORLD_READABLE);
+        } catch (Exception e) {
+            pref = null;
+        }
+
+        if (pref == null) {
+            new AlertDialog.Builder(this)
+                    .setTitle("Module Not Enabled")
+                    .setMessage("The Xposed module is not enabled. Please enable it in your Xposed framework.")
+                    .setPositiveButton("OK", (dialogInterface, i) -> finish())
+                    .show();
+
+        } else {
+            if (savedInstanceState == null) {
+                getSupportFragmentManager()
+                        .beginTransaction()
+                        .replace(R.id.settings_container, new MainPreferenceFragment())
+                        .commit();
+            }
+
         }
     }
 


### PR DESCRIPTION
[檢測參考](https://github.com/BaltiApps/Pixelify-Google-Photos/blob/c5069b0767180b17b25faa0a222d371b88da49d7/app/src/main/java/balti/xposed/pixelifygooglephotos/ActivityMain.kt#L45)